### PR TITLE
:bug: bug fixed show untracked file

### DIFF
--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -180,7 +180,7 @@ project root was found."
 
 (defun consult-ls-git--status-candidates ()
   "Return a list of paths that are considered modified in some way by git."
-  (let* ((options (append `(,(when consult-ls-git-show-untracked-files "-uno")
+  (let* ((options (append `(,(unless consult-ls-git-show-untracked-files "-uno")
                             "--porcelain")
                           consult-ls-git-status-command-options))
          (candidates (consult-ls-git--candidates-from-git-command


### PR DESCRIPTION
Hello!
I've been finding your package very useful. Thank you!

It seems that the fix at https://github.com/rcj/consult-ls-git/commit/7ac83c847a646084fd5e9d170df33ef580fe18b1 is causing `consult-ls-git-show-untracked-files` to not work properly.

So I tried rewriting the code while keeping the meaning of `consult-ls-git-show-untracked-files` the same. Please check it out.