### PR TITLE
Fix error when consult-ls-git-show-untracked-files is nil

### DIFF
--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -188,6 +188,7 @@ project root was found."
   (let* ((options (append `(,(if consult-ls-git-show-untracked-files "-uno" "")
                             "--porcelain")
                           consult-ls-git-status-command-options))
+         (options (cl-remove-if (lambda (value) (string-equal value "")) options))
          (candidates (consult-ls-git--candidates-from-git-command
                       "status" default-directory options)))
     (save-match-data

--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -185,10 +185,9 @@ project root was found."
 
 (defun consult-ls-git--status-candidates ()
   "Return a list of paths that are considered modified in some way by git."
-  (let* ((options (append `(,(if consult-ls-git-show-untracked-files "-uno" "")
+  (let* ((options (append `(,@(unless consult-ls-git-show-untracked-files '("-uno"))
                             "--porcelain")
                           consult-ls-git-status-command-options))
-         (options (cl-remove-if (lambda (value) (string-equal value "")) options))
          (candidates (consult-ls-git--candidates-from-git-command
                       "status" default-directory options)))
     (save-match-data


### PR DESCRIPTION
In this case an empty string is used as a git argument and that
product the following error in the status section:

fatal: empty string is not a valid pathspec. please use . instead if
you meant to match all paths