### PR TITLE
Fix the customization type

### DIFF
--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -72,7 +72,7 @@
     ("^.*" . unknown))
   "Match a git status abbreviation to a readable string."
   :group 'consult-ls-git
-  :type '(repeat (string . function)))
+  :type '(alist :key-type string :value-type function))
 
 (defcustom consult-ls-git-stash-actions
   '(("apply" . vc-git-stash-apply)
@@ -81,7 +81,7 @@
     ("show" . vc-git-stash-show))
   "List of possible actions to invoke on a stash."
   :group 'consult-ls-git
-  :type '(repeat (string . function)))
+  :type '(alist :key-type string :value-type function))
 
 (defcustom consult-ls-git-status-command-options nil
   "List of command line options passed to git status to determine candidates."


### PR DESCRIPTION
The type `(repeat (string . function))` of the custom variables is invalid. You can't simply pass a cons cell of two types to denote a composite type. It caused an error when the library was byte-compiled, which is fixed with the changes in this PR.