### PR TITLE
Fixed tramp-file-local-name not being defined at compile time

### DIFF
--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -46,6 +46,8 @@
 (require 'consult)
 (require 'project)
 (require 'vc)
+(eval-when-compile
+  (declare-function tramp-file-local-name "tramp" (name)))
 
 (defgroup consult-ls-git nil
   "Consult for git."


### PR DESCRIPTION
The following error occurs in Emacs 30:

```
⛔ Warning (native-compiler): consult-ls-git.el:156:20: Warning: the function ‘tramp-file-local-name’ is not known to be defined.
```