### PR TITLE
feat: add support for viewing ignored files in git repositories

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,6 +11,7 @@ Alternatively you can narrow to a specific section via the shortcut key:
 - s: Status
 - z: Stash
 - f: Tracked Files
+- i: Ignored Files (Note: This source is not included by default in `consult-ls-git`, see `consult-ls-git-sources`)
 
 If =default-directory= is inside a git repository, it will use this
 repository. Otherwise `consult-ls-git-project-prompt-function' is used
@@ -21,10 +22,7 @@ Each view also has a standalone command in case that is preferable:
 - =consult-ls-git-status=
 - =consult-ls-git-stash=
 - =consult-ls-git-tracked-files=
-
-Additionally, there are standalone commands to specifically view ignored files:
-- =consult-ls-git-ls-ignored=
-- =consult-ls-git-ls-ignored-other-window=
+- =consult-ls-git-ignored= (Provides access to ignored files, not included in the default `consult-ls-git` view)
 
 * Examples
   - [[file:examples/consult-ls-git-status.gif][Status narrowing]]

--- a/README.org
+++ b/README.org
@@ -22,6 +22,10 @@ Each view also has a standalone command in case that is preferable:
 - =consult-ls-git-stash=
 - =consult-ls-git-tracked-files=
 
+Additionally, there are standalone commands to specifically view ignored files:
+- =consult-ls-git-ls-ignored=
+- =consult-ls-git-ls-ignored-other-window=
+
 * Examples
   - [[file:examples/consult-ls-git-status.gif][Status narrowing]]
   - [[file:videos/consult-ls-git-stash.gif][Stash narrowing]]

--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -57,7 +57,7 @@
   '(consult-ls-git--source-status-files
     consult-ls-git--source-stash
     consult-ls-git--source-tracked-files)
-  "Sources used by `consult-ls-git'."
+  "Default sources used by `consult-ls-git'. Does not include ignored files by default."
   :group 'consult-ls-git
   :type '(repeat symbol))
 
@@ -105,6 +105,11 @@
   :group 'consult-ls-git
   :type '(repeat string))
 
+(defcustom consult-ls-git-ignored-files-command-options nil
+  "List of command line options passed to git ls-files --ignored --exclude-standard to determine candidates."
+  :group 'consult-ls-git
+  :type '(repeat string))
+
 (defcustom consult-ls-git-project-prompt-function
   (if (version< emacs-version "28.1")
       (lambda () (cdr (funcall #'consult--directory-prompt "Select project: " 'ask)))
@@ -130,6 +135,19 @@
           (consult-ls-git--candidates-from-git-command
            "ls-files" default-directory
            consult-ls-git-tracked-files-command-options))))
+
+(defvar consult-ls-git--source-ignored-files
+  (list :name     "Ignored Files"
+        :narrow   '(?i . "Ignored Files")
+        :category 'file
+        :face     'consult-file
+        :history  'file-name-history
+        :state    #'consult--file-state
+        :items
+        (lambda ()
+          (consult-ls-git--candidates-from-git-command
+           "ls-files --others --ignored --exclude-standard" default-directory
+           consult-ls-git-ignored-files-command-options))))
 
 (defvar consult-ls-git--source-status-files
   (list :name     "Status"
@@ -274,6 +292,20 @@ Untracked files are only included if
   (interactive)
   (let ((consult-ls-git-sources '(consult-ls-git--source-stash)))
     (call-interactively #'consult-ls-git)))
+
+;;;###autoload
+(defun consult-ls-git-ls-ignored ()
+  "Select an ignored file from a git repository."
+  (interactive)
+  (let ((consult-ls-git-sources '(consult-ls-git--source-ignored-files)))
+    (call-interactively #'consult-ls-git)))
+
+;;;###autoload
+(defun consult-ls-git-ls-ignored-other-window ()
+  "Select an ignored file from a git repository and open it in another window."
+  (interactive)
+  (let ((consult-ls-git-sources '(consult-ls-git--source-ignored-files)))
+    (call-interactively #'consult-ls-git-other-window)))
 
 (provide 'consult-ls-git)
 ;;; consult-ls-git.el ends here

--- a/consult-ls-git.el
+++ b/consult-ls-git.el
@@ -57,7 +57,7 @@
   '(consult-ls-git--source-status-files
     consult-ls-git--source-stash
     consult-ls-git--source-tracked-files)
-  "Default sources used by `consult-ls-git'. Does not include ignored files by default."
+  "Sources used by `consult-ls-git'. Does not include ignored files by default."
   :group 'consult-ls-git
   :type '(repeat symbol))
 


### PR DESCRIPTION
- Introduce new standalone commands `consult-ls-git-ls-ignored` and `consult-ls-git-ls-ignored-other-window` to view ignored files.
- Add a new customizable variable `consult-ls-git-ignored-files-command-options` for specifying command-line options for ignored files. 
- Update the explanation of default sources to exclude ignored files by default.